### PR TITLE
fix: undefined glyphType and nested lists

### DIFF
--- a/e2e/__html__/complete.json.html
+++ b/e2e/__html__/complete.json.html
@@ -89,12 +89,18 @@
   Bordered paragraph
 </p>
 <h1 style="text-align: justify" class="heading-1" id="lists">Lists</h1>
-<ol class="nesting-level-1">
+<ul class="nesting-level-1">
   <li>Unordered list bullet</li>
-  <li>Nested unordered list bullet</li>
+  <ul class="nesting-level-2">
+    <li>Nested unordered list bullet</li>
+  </ul>
   <li>Another list bullet</li>
+</ul>
+<ol class="nesting-level-1" list-style-type="decimal">
   <li>Ordered listed bullet</li>
-  <li>Nested ordered list bullet</li>
+  <ol class="nesting-level-2" list-style-type="lower-alpha">
+    <li>Nested ordered list bullet</li>
+  </ol>
   <li>Another list bullet</li>
 </ol>
 <h1 style="text-align: justify" class="heading-1" id="tables">Tables</h1>

--- a/e2e/__html__/complete.json.html
+++ b/e2e/__html__/complete.json.html
@@ -90,17 +90,21 @@
 </p>
 <h1 style="text-align: justify" class="heading-1" id="lists">Lists</h1>
 <ul class="nesting-level-1">
-  <li>Unordered list bullet</li>
-  <ul class="nesting-level-2">
-    <li>Nested unordered list bullet</li>
-  </ul>
+  <li>
+    Unordered list bullet
+    <ul class="nesting-level-2">
+      <li>Nested unordered list bullet</li>
+    </ul>
+  </li>
   <li>Another list bullet</li>
 </ul>
 <ol class="nesting-level-1" list-style-type="decimal">
-  <li>Ordered listed bullet</li>
-  <ol class="nesting-level-2" list-style-type="lower-alpha">
-    <li>Nested ordered list bullet</li>
-  </ol>
+  <li>
+    Ordered listed bullet
+    <ol class="nesting-level-2" list-style-type="lower-alpha">
+      <li>Nested ordered list bullet</li>
+    </ol>
+  </li>
   <li>Another list bullet</li>
 </ol>
 <h1 style="text-align: justify" class="heading-1" id="tables">Tables</h1>

--- a/e2e/__html__/complete.json_styles_false.html
+++ b/e2e/__html__/complete.json_styles_false.html
@@ -46,12 +46,18 @@
 <p class="normal-text">Indented</p>
 <p class="normal-text">Bordered paragraph</p>
 <h1 class="heading-1" id="lists">Lists</h1>
-<ol class="nesting-level-1">
+<ul class="nesting-level-1">
   <li>Unordered list bullet</li>
-  <li>Nested unordered list bullet</li>
+  <ul class="nesting-level-2">
+    <li>Nested unordered list bullet</li>
+  </ul>
   <li>Another list bullet</li>
+</ul>
+<ol class="nesting-level-1" list-style-type="decimal">
   <li>Ordered listed bullet</li>
-  <li>Nested ordered list bullet</li>
+  <ol class="nesting-level-2" list-style-type="lower-alpha">
+    <li>Nested ordered list bullet</li>
+  </ol>
   <li>Another list bullet</li>
 </ol>
 <h1 class="heading-1" id="tables">Tables</h1>

--- a/e2e/__html__/complete.json_styles_false.html
+++ b/e2e/__html__/complete.json_styles_false.html
@@ -47,17 +47,21 @@
 <p class="normal-text">Bordered paragraph</p>
 <h1 class="heading-1" id="lists">Lists</h1>
 <ul class="nesting-level-1">
-  <li>Unordered list bullet</li>
-  <ul class="nesting-level-2">
-    <li>Nested unordered list bullet</li>
-  </ul>
+  <li>
+    Unordered list bullet
+    <ul class="nesting-level-2">
+      <li>Nested unordered list bullet</li>
+    </ul>
+  </li>
   <li>Another list bullet</li>
 </ul>
 <ol class="nesting-level-1" list-style-type="decimal">
-  <li>Ordered listed bullet</li>
-  <ol class="nesting-level-2" list-style-type="lower-alpha">
-    <li>Nested ordered list bullet</li>
-  </ol>
+  <li>
+    Ordered listed bullet
+    <ol class="nesting-level-2" list-style-type="lower-alpha">
+      <li>Nested ordered list bullet</li>
+    </ol>
+  </li>
   <li>Another list bullet</li>
 </ol>
 <h1 class="heading-1" id="tables">Tables</h1>

--- a/e2e/__snapshots__/hast.test.ts.snap
+++ b/e2e/__snapshots__/hast.test.ts.snap
@@ -732,26 +732,26 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
             {
               "type": "text",
               "value": "Unordered list bullet"
-            }
-          ]
-        },
-        {
-          "type": "element",
-          "tagName": "ul",
-          "properties": {
-            "className": [
-              "nesting-level-2"
-            ]
-          },
-          "children": [
+            },
             {
               "type": "element",
-              "tagName": "li",
-              "properties": {},
+              "tagName": "ul",
+              "properties": {
+                "className": [
+                  "nesting-level-2"
+                ]
+              },
               "children": [
                 {
-                  "type": "text",
-                  "value": "Nested unordered list bullet"
+                  "type": "element",
+                  "tagName": "li",
+                  "properties": {},
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Nested unordered list bullet"
+                    }
+                  ]
                 }
               ]
             }
@@ -788,27 +788,27 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
             {
               "type": "text",
               "value": "Ordered listed bullet"
-            }
-          ]
-        },
-        {
-          "type": "element",
-          "tagName": "ol",
-          "properties": {
-            "className": [
-              "nesting-level-2"
-            ],
-            "list-style-type": "lower-alpha"
-          },
-          "children": [
+            },
             {
               "type": "element",
-              "tagName": "li",
-              "properties": {},
+              "tagName": "ol",
+              "properties": {
+                "className": [
+                  "nesting-level-2"
+                ],
+                "list-style-type": "lower-alpha"
+              },
               "children": [
                 {
-                  "type": "text",
-                  "value": "Nested ordered list bullet"
+                  "type": "element",
+                  "tagName": "li",
+                  "properties": {},
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Nested ordered list bullet"
+                    }
+                  ]
                 }
               ]
             }
@@ -2986,26 +2986,26 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
             {
               "type": "text",
               "value": "Unordered list bullet"
-            }
-          ]
-        },
-        {
-          "type": "element",
-          "tagName": "ul",
-          "properties": {
-            "className": [
-              "nesting-level-2"
-            ]
-          },
-          "children": [
+            },
             {
               "type": "element",
-              "tagName": "li",
-              "properties": {},
+              "tagName": "ul",
+              "properties": {
+                "className": [
+                  "nesting-level-2"
+                ]
+              },
               "children": [
                 {
-                  "type": "text",
-                  "value": "Nested unordered list bullet"
+                  "type": "element",
+                  "tagName": "li",
+                  "properties": {},
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Nested unordered list bullet"
+                    }
+                  ]
                 }
               ]
             }
@@ -3042,27 +3042,27 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
             {
               "type": "text",
               "value": "Ordered listed bullet"
-            }
-          ]
-        },
-        {
-          "type": "element",
-          "tagName": "ol",
-          "properties": {
-            "className": [
-              "nesting-level-2"
-            ],
-            "list-style-type": "lower-alpha"
-          },
-          "children": [
+            },
             {
               "type": "element",
-              "tagName": "li",
-              "properties": {},
+              "tagName": "ol",
+              "properties": {
+                "className": [
+                  "nesting-level-2"
+                ],
+                "list-style-type": "lower-alpha"
+              },
               "children": [
                 {
-                  "type": "text",
-                  "value": "Nested ordered list bullet"
+                  "type": "element",
+                  "tagName": "li",
+                  "properties": {},
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Nested ordered list bullet"
+                    }
+                  ]
                 }
               ]
             }

--- a/e2e/__snapshots__/hast.test.ts.snap
+++ b/e2e/__snapshots__/hast.test.ts.snap
@@ -717,7 +717,7 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
     },
     {
       "type": "element",
-      "tagName": "ol",
+      "tagName": "ul",
       "properties": {
         "className": [
           "nesting-level-1"
@@ -737,12 +737,23 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
         },
         {
           "type": "element",
-          "tagName": "li",
-          "properties": {},
+          "tagName": "ul",
+          "properties": {
+            "className": [
+              "nesting-level-2"
+            ]
+          },
           "children": [
             {
-              "type": "text",
-              "value": "Nested unordered list bullet"
+              "type": "element",
+              "tagName": "li",
+              "properties": {},
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Nested unordered list bullet"
+                }
+              ]
             }
           ]
         },
@@ -756,7 +767,19 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
               "value": "Another list bullet"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "tagName": "ol",
+      "properties": {
+        "className": [
+          "nesting-level-1"
+        ],
+        "list-style-type": "decimal"
+      },
+      "children": [
         {
           "type": "element",
           "tagName": "li",
@@ -770,12 +793,24 @@ exports[`%name { name: 'complete.json' } > hast 1`] = `
         },
         {
           "type": "element",
-          "tagName": "li",
-          "properties": {},
+          "tagName": "ol",
+          "properties": {
+            "className": [
+              "nesting-level-2"
+            ],
+            "list-style-type": "lower-alpha"
+          },
           "children": [
             {
-              "type": "text",
-              "value": "Nested ordered list bullet"
+              "type": "element",
+              "tagName": "li",
+              "properties": {},
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Nested ordered list bullet"
+                }
+              ]
             }
           ]
         },
@@ -2936,7 +2971,7 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
     },
     {
       "type": "element",
-      "tagName": "ol",
+      "tagName": "ul",
       "properties": {
         "className": [
           "nesting-level-1"
@@ -2956,12 +2991,23 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
         },
         {
           "type": "element",
-          "tagName": "li",
-          "properties": {},
+          "tagName": "ul",
+          "properties": {
+            "className": [
+              "nesting-level-2"
+            ]
+          },
           "children": [
             {
-              "type": "text",
-              "value": "Nested unordered list bullet"
+              "type": "element",
+              "tagName": "li",
+              "properties": {},
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Nested unordered list bullet"
+                }
+              ]
             }
           ]
         },
@@ -2975,7 +3021,19 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
               "value": "Another list bullet"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "type": "element",
+      "tagName": "ol",
+      "properties": {
+        "className": [
+          "nesting-level-1"
+        ],
+        "list-style-type": "decimal"
+      },
+      "children": [
         {
           "type": "element",
           "tagName": "li",
@@ -2989,12 +3047,24 @@ exports[`%name { name: 'complete.json' } > hast without styles 1`] = `
         },
         {
           "type": "element",
-          "tagName": "li",
-          "properties": {},
+          "tagName": "ol",
+          "properties": {
+            "className": [
+              "nesting-level-2"
+            ],
+            "list-style-type": "lower-alpha"
+          },
           "children": [
             {
-              "type": "text",
-              "value": "Nested ordered list bullet"
+              "type": "element",
+              "tagName": "li",
+              "properties": {},
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Nested ordered list bullet"
+                }
+              ]
             }
           ]
         },

--- a/e2e/__snapshots__/html.test.ts.snap
+++ b/e2e/__snapshots__/html.test.ts.snap
@@ -92,12 +92,18 @@ exports[`%name { name: 'complete.json' } > html 1`] = `
   Bordered paragraph
 </p>
 <h1 style="text-align: justify" class="heading-1" id="lists">Lists</h1>
-<ol class="nesting-level-1">
+<ul class="nesting-level-1">
   <li>Unordered list bullet</li>
-  <li>Nested unordered list bullet</li>
+  <ul class="nesting-level-2">
+    <li>Nested unordered list bullet</li>
+  </ul>
   <li>Another list bullet</li>
+</ul>
+<ol class="nesting-level-1" list-style-type="decimal">
   <li>Ordered listed bullet</li>
-  <li>Nested ordered list bullet</li>
+  <ol class="nesting-level-2" list-style-type="lower-alpha">
+    <li>Nested ordered list bullet</li>
+  </ol>
   <li>Another list bullet</li>
 </ol>
 <h1 style="text-align: justify" class="heading-1" id="tables">Tables</h1>
@@ -535,12 +541,18 @@ exports[`%name { name: 'complete.json' } > html without styles 1`] = `
 <p class="normal-text">Indented</p>
 <p class="normal-text">Bordered paragraph</p>
 <h1 class="heading-1" id="lists">Lists</h1>
-<ol class="nesting-level-1">
+<ul class="nesting-level-1">
   <li>Unordered list bullet</li>
-  <li>Nested unordered list bullet</li>
+  <ul class="nesting-level-2">
+    <li>Nested unordered list bullet</li>
+  </ul>
   <li>Another list bullet</li>
+</ul>
+<ol class="nesting-level-1" list-style-type="decimal">
   <li>Ordered listed bullet</li>
-  <li>Nested ordered list bullet</li>
+  <ol class="nesting-level-2" list-style-type="lower-alpha">
+    <li>Nested ordered list bullet</li>
+  </ol>
   <li>Another list bullet</li>
 </ol>
 <h1 class="heading-1" id="tables">Tables</h1>

--- a/e2e/__snapshots__/html.test.ts.snap
+++ b/e2e/__snapshots__/html.test.ts.snap
@@ -93,17 +93,21 @@ exports[`%name { name: 'complete.json' } > html 1`] = `
 </p>
 <h1 style="text-align: justify" class="heading-1" id="lists">Lists</h1>
 <ul class="nesting-level-1">
-  <li>Unordered list bullet</li>
-  <ul class="nesting-level-2">
-    <li>Nested unordered list bullet</li>
-  </ul>
+  <li>
+    Unordered list bullet
+    <ul class="nesting-level-2">
+      <li>Nested unordered list bullet</li>
+    </ul>
+  </li>
   <li>Another list bullet</li>
 </ul>
 <ol class="nesting-level-1" list-style-type="decimal">
-  <li>Ordered listed bullet</li>
-  <ol class="nesting-level-2" list-style-type="lower-alpha">
-    <li>Nested ordered list bullet</li>
-  </ol>
+  <li>
+    Ordered listed bullet
+    <ol class="nesting-level-2" list-style-type="lower-alpha">
+      <li>Nested ordered list bullet</li>
+    </ol>
+  </li>
   <li>Another list bullet</li>
 </ol>
 <h1 style="text-align: justify" class="heading-1" id="tables">Tables</h1>
@@ -542,17 +546,21 @@ exports[`%name { name: 'complete.json' } > html without styles 1`] = `
 <p class="normal-text">Bordered paragraph</p>
 <h1 class="heading-1" id="lists">Lists</h1>
 <ul class="nesting-level-1">
-  <li>Unordered list bullet</li>
-  <ul class="nesting-level-2">
-    <li>Nested unordered list bullet</li>
-  </ul>
+  <li>
+    Unordered list bullet
+    <ul class="nesting-level-2">
+      <li>Nested unordered list bullet</li>
+    </ul>
+  </li>
   <li>Another list bullet</li>
 </ul>
 <ol class="nesting-level-1" list-style-type="decimal">
-  <li>Ordered listed bullet</li>
-  <ol class="nesting-level-2" list-style-type="lower-alpha">
-    <li>Nested ordered list bullet</li>
-  </ol>
+  <li>
+    Ordered listed bullet
+    <ol class="nesting-level-2" list-style-type="lower-alpha">
+      <li>Nested ordered list bullet</li>
+    </ol>
+  </li>
   <li>Another list bullet</li>
 </ol>
 <h1 class="heading-1" id="tables">Tables</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2999,9 +2999,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -4446,15 +4446,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-      "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4994,7 +4994,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -5695,7 +5696,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -6736,9 +6738,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -7729,16 +7731,16 @@
       }
     },
     "vite": {
-      "version": "2.9.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-      "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       }
     },
     "vitest": {

--- a/src/hast/index.ts
+++ b/src/hast/index.ts
@@ -121,26 +121,35 @@ const structuralElementToElement = (
 
   if (paragraph) {
     const last = elements[index - 1];
-    const parent = acc[acc.length - 1];
+    const parent = acc.at(-1); //[acc.length - 1];
 
     const renderedElement: Element = paragraphToElement(paragraph, context);
 
     if (isListItem(el)) {
-      if (isListItem(last) && listItemBulletId(el) == listItemBulletId(last)) {
-        // traverse from top level `parent` to last rendered element somewhere deep inside
+      const elListItemLevel = listItemLevel(el);
+      if (
+        isListItem(last) &&
+        (listItemBulletId(el) == listItemBulletId(last) || elListItemLevel > 0)
+      ) {
+        const lastListItemLevel = listItemLevel(last);
         let level: Element = parent;
-        for (let i = 2; i < 2 * listItemLevel(el) - 1; i++) {
-          level = getElementLastChild(level);
-        }
         // nested list item
-        if (listItemLevel(el) > listItemLevel(last)) {
+        if (elListItemLevel > lastListItemLevel) {
+          // traverse from top level `parent` to last rendered element somewhere deep inside
+          for (let i = 0; i < 2 * lastListItemLevel; i++) {
+            level = getElementLastChild(level);
+          }
           const list = listElement(el, context);
           list.children.push(renderedElement);
-          level.children.push(list);
+          getElementLastChild(level).children.push(list);
           return null;
         }
         // item on existing list
         else {
+          // traverse from top level `parent` to last rendered element somewhere deep inside
+          for (let i = 0; i < 2 * elListItemLevel; i++) {
+            level = getElementLastChild(level);
+          }
           level.children.push(renderedElement);
           return null;
         }
@@ -166,6 +175,8 @@ const structuralElementToElement = (
       .pop()}`
   );
 };
+const isElement = (element: Element): element is Element =>
+  element.type === "element";
 const getElementLastChild = (el: Element): Element => {
-  return el.children.filter((e) => e.type == "element").at(-1) as Element;
+  return el.children.filter(isElement).at(-1);
 };

--- a/src/hast/index.ts
+++ b/src/hast/index.ts
@@ -122,16 +122,21 @@ const structuralElementToElement = (
 
     if (isListItem(el)) {
       if (isListItem(last)) {
+        // traverse from top level `parent` to last rendered element somewhere deep inside
+        let level: Element = parent;
+        for (let i = 0; i < 2 * listItemLevel(el); i++) {
+          level = getElementLastChild(level);
+        }
         // nested list item
         if (listItemLevel(el) > listItemLevel(last)) {
           const list = listElement(el, context);
           list.children.push(renderedElement);
-          parent.children.push(list);
+          level.children.push(list);
           return null;
         }
         // item on existing list
         else {
-          parent.children.push(renderedElement);
+          getElementLastChild(level).children.push(renderedElement);
           return null;
         }
       }
@@ -155,4 +160,7 @@ const structuralElementToElement = (
       .filter((k) => !k.match(/.*Index$/))
       .pop()}`
   );
+};
+const getElementLastChild = (el: Element): Element => {
+  return el.children.filter((e) => e.type == "element").at(-1) as Element;
 };

--- a/src/hast/index.ts
+++ b/src/hast/index.ts
@@ -16,7 +16,12 @@
 
 import { h } from "hastscript";
 
-import { listElement, isListItem, listItemLevel } from "./lists";
+import {
+  listElement,
+  isListItem,
+  listItemLevel,
+  listItemBulletId,
+} from "./lists";
 import { paragraphToElement } from "./paragraph";
 import { replaceHeaderIdsWithSlug } from "./postProcessing/prettyHeaderIds";
 import { removeStyles } from "./postProcessing/removeStyles";
@@ -121,10 +126,10 @@ const structuralElementToElement = (
     const renderedElement: Element = paragraphToElement(paragraph, context);
 
     if (isListItem(el)) {
-      if (isListItem(last)) {
+      if (isListItem(last) && listItemBulletId(el) == listItemBulletId(last)) {
         // traverse from top level `parent` to last rendered element somewhere deep inside
         let level: Element = parent;
-        for (let i = 0; i < 2 * listItemLevel(el); i++) {
+        for (let i = 2; i < 2 * listItemLevel(el) - 1; i++) {
           level = getElementLastChild(level);
         }
         // nested list item
@@ -136,7 +141,7 @@ const structuralElementToElement = (
         }
         // item on existing list
         else {
-          getElementLastChild(level).children.push(renderedElement);
+          level.children.push(renderedElement);
           return null;
         }
       }

--- a/src/hast/lists.ts
+++ b/src/hast/lists.ts
@@ -27,6 +27,11 @@ export const isListItem = (el: docs_v1.Schema$StructuralElement): boolean => {
 export const listItemLevel = (el: docs_v1.Schema$StructuralElement): number => {
   return el.paragraph.bullet.nestingLevel ?? 0;
 };
+export const listItemBulletId = (
+  el: docs_v1.Schema$StructuralElement
+): string => {
+  return el.paragraph.bullet.listId;
+};
 
 export const listElement = (
   el: docs_v1.Schema$StructuralElement,

--- a/src/hast/lists.ts
+++ b/src/hast/lists.ts
@@ -25,7 +25,7 @@ export const isListItem = (el: docs_v1.Schema$StructuralElement): boolean => {
 };
 
 export const listItemLevel = (el: docs_v1.Schema$StructuralElement): number => {
-  return el.paragraph.bullet.nestingLevel ?? 1;
+  return el.paragraph.bullet.nestingLevel ?? 0;
 };
 
 export const listElement = (
@@ -34,12 +34,12 @@ export const listElement = (
 ): Element => {
   const { listId } = el.paragraph.bullet;
   let { nestingLevel } = el.paragraph.bullet;
-  nestingLevel = nestingLevel ?? 1;
+  nestingLevel = nestingLevel ?? 0;
   const { glyphType, startNumber } =
-    doc.lists[listId].listProperties.nestingLevels[nestingLevel - 1];
+    doc.lists[listId].listProperties.nestingLevels[nestingLevel];
 
   const attributes = {
-    class: `nesting-level-${nestingLevel}`,
+    class: `nesting-level-${nestingLevel + 1}`,
   };
 
   if ([undefined, "GLYPH_TYPE_UNSPECIFIED", "NONE"].includes(glyphType)) {


### PR DESCRIPTION
It seems like GoogleDocs API does not set `glyphType` for unordered lists