### PR TITLE
fix: construction of person href with mailto

### DIFF
--- a/src/hast/paragraph/person.test.ts
+++ b/src/hast/paragraph/person.test.ts
@@ -39,7 +39,7 @@ describe("person", () => {
           },
         ],
         "properties": {
-          "mailto": "john@example.com",
+          "href": "mailto:john@example.com",
         },
         "tagName": "a",
         "type": "element",
@@ -62,7 +62,7 @@ describe("person", () => {
           },
         ],
         "properties": {
-          "mailto": "john@example.com",
+          "href": "mailto:john@example.com",
         },
         "tagName": "a",
         "type": "element",

--- a/src/hast/paragraph/person.ts
+++ b/src/hast/paragraph/person.ts
@@ -26,7 +26,7 @@ export const transformPerson = (
   wrapStyle(
     h(
       "a",
-      { mailto: person.personProperties.email },
+      { href: `mailto:${person.personProperties.email}` },
       person.personProperties.name ?? person.personProperties.email
     ),
     person.textStyle


### PR DESCRIPTION
Fixed construction of <a> anchor elements for a person to have an href attribute with a value starting with `mailto:`. 

Previously a `mailto` attribute was created instead of `href` which is not a standard attribute of an anchor element.   