### PR TITLE
fix: Added defaults to `rgbColor` arg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4994,7 +4994,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -5695,7 +5696,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",

--- a/src/hast/common/style.ts
+++ b/src/hast/common/style.ts
@@ -116,9 +116,7 @@ const isParagraphBorder = (
 };
 
 export const rgbColor = ({
-  color: {
-    rgbColor: { red = 0, green = 0, blue = 0 },
-  },
+  color: { rgbColor: { red = 0, green = 0, blue = 0 } = {} } = {},
 }: docs_v1.Schema$OptionalColor): string => {
   return `rgb(${red * 255}, ${green * 255}, ${blue * 255})`;
 };


### PR DESCRIPTION
Added missing defaults to destructured arg passed to `rgbColor` function.